### PR TITLE
Making SQuAD to return json (no public API change)

### DIFF
--- a/gluonnlp/data/question_answering.py
+++ b/gluonnlp/data/question_answering.py
@@ -80,7 +80,7 @@ class SQuAD(ArrayDataset):
         self._segment = segment
         self._get_data()
 
-        super(SQuAD, self).__init__(self._read_data())
+        super(SQuAD, self).__init__(SQuAD._get_records(self._read_data()))
 
     def _get_data(self):
         """Load data from the file. Does nothing if data was loaded before
@@ -116,9 +116,9 @@ class SQuAD(ArrayDataset):
         _, data_file_name, _ = self._data_file[self._segment]
 
         with open(os.path.join(self._root, data_file_name)) as f:
-            samples = json.load(f)
+            json_data = json.load(f)
 
-        return SQuAD._get_records(samples)
+        return json_data
 
     @staticmethod
     def _get_records(json_dict):


### PR DESCRIPTION
## Description ##
Better responsibility separation. `_read_data()` now just only reads the json into memory, not parses it. It allows to get the json as-is later, if needed. I use it to plug in official evaluation script

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] `_read_data` method only reads json file, not parses it
